### PR TITLE
feat(deps): Bump Micronaut platform to 5.0.0 (GA)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -219,7 +219,7 @@ ext {
     // enforcedPlatform(:grails-micronaut-bom).
     else if (project.name == 'grails-micronaut-bom') {
         customBomVersions = [
-                'groovy.version'  : '5.0.5',
+                'groovy.version'  : '5.0.6',
                 'spock.version'   : '2.4-groovy-5.0',
                 'protobuf.version': '4.30.2',
         ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ gradleChecksumPluginVersion=1.4.0
 gradleCycloneDxPluginVersion=3.0.0
 
 # micronaut libraries not in the bom due to the potential for spring mismatches
-micronautPlatformVersion=5.0.0-M2
+micronautPlatformVersion=5.0.0
 micronautRxjava2Version=2.9.0
 micronautSerdeJacksonVersion=2.11.0
 

--- a/grails-bom/micronaut/build.gradle
+++ b/grails-bom/micronaut/build.gradle
@@ -76,9 +76,11 @@ dependencies {
     // managed versions transitively and don't need to declare the platform themselves.
     // Exclude Groovy since we declare the required version explicitly below via customBomDependencies.
     // Exclude Spock since the base BOM manages that version.
-    // Exclude Jackson 3 (tools.jackson) since spring-boot-dependencies manages that version,
-    // and Micronaut can lag behind Spring Boot's patch bumps (e.g. SB 4.0.6 ships
-    // jackson-bom 3.1.2 while micronaut-platform 5.0.0-M2 still pins 3.1.0).
+    // Exclude Jackson 3 (tools.jackson) since spring-boot-dependencies manages that version
+    // and the two platforms routinely disagree on the patch (e.g. SB 4.0.6 ships
+    // jackson-bom 3.1.2 while micronaut-platform 5.0.0 pins 3.1.3). Let Spring Boot
+    // remain the single source of truth so the dependency-version validator does not
+    // see drift between probe and project resolution.
     api(platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")) {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'


### PR DESCRIPTION
**Draft - stacked on top of #15675.** This PR uses the Spring Boot 4.0.6 branch (`deps/spring-boot-4.0.6`) as its base so the dependency-version fallout from that bump does not muddy this one.

Bumps `micronautPlatformVersion` from `5.0.0-M2` to `5.0.0` (GA, published to Maven Central on 2026-05-20).

Release notes / changelog: https://github.com/micronaut-projects/micronaut-platform/releases/tag/v5.0.0
Maven Central: https://repo1.maven.org/maven2/io/micronaut/platform/micronaut-platform/5.0.0/

## What's in this first commit

The minimum change set that keeps `validateDependencyVersions` green after the bump:

- `gradle.properties`: `micronautPlatformVersion=5.0.0-M2` -> `5.0.0`.
- `dependencies.gradle`: bump the `grails-micronaut-bom` Groovy override from `5.0.5` to `5.0.6` so our strict pin matches Micronaut 5 GA's managed `groovy.version`. Spock stays at `2.4-groovy-5.0` (unchanged in GA).
- `grails-bom/micronaut/build.gradle`: refresh the comment on the `tools.jackson` exclude. Micronaut 5.0.0 ships `jackson-bom 3.1.3` while Spring Boot 4.0.6 ships `3.1.2` - the platforms still disagree on the patch, just in the opposite direction now. The exclude itself stays in place so `spring-boot-dependencies` remains the single source of truth for Jackson 3.

## Notable upstream version moves (5.0.0-M2 -> 5.0.0)

Read directly from the published `micronaut-platform-5.0.0.pom`:

| Property | M2 | 5.0.0 GA |
|---|---|---|
| `micronaut.core.version` | `5.0.0-M23` | `5.0.0` |
| `micronaut.data.version` | `5.0.0-M5` | `5.0.1` |
| `micronaut.serde.version` | `3.0.0-M7` | `3.0.0` |
| `micronaut.mongo.version` / `micronaut.mongodb.version` | `6.0.1-M1` | `6.0.1` |
| `micronaut.langchain4j.version` | `2.0.0-M1` | `2.0.0` |
| `jackson.version` | `3.1.0` | `3.1.3` |
| `groovy.version` | `5.0.4` | `5.0.6` |
| `spock.version` | `2.4-groovy-5.0` | `2.4-groovy-5.0` |
| `spring.boot.version` | `4.0.3` | `4.0.6` (matches our pin) |
| `spring.version` | `7.0.6` | `7.0.7` |

## Known platform-level breaking changes

From the v5.0.0 release notes - flagged here so reviewers know what to watch for in subsequent commits:

- **RxJava 2 removed from BOM.** `io.reactivex:rxjava` and `io.micronaut.rxjava2:*` are no longer managed by the platform. Our `micronautRxjava2Version=2.9.0` in `gradle.properties` is already floated outside the BOM (comment: "micronaut libraries not in the bom due to the potential for spring mismatches"), so the existing pin still works - but consumers should be aware.
- **MicroStream removed from BOM.** Replaced by EclipseStore (`micronaut.eclipsestore.version=2.0.0`).
- **`jaxrs.api.version` 3.1.0 -> 4.0.0** (Jakarta RESTful Web Services 4).
- **`kafka.version` 3.9.1 -> 4.2.0** - major Kafka client jump.

None of these affect anything `grails-core` currently consumes, but they are landmines for downstream Grails-on-Micronaut apps.

## What is NOT addressed yet

This PR intentionally ships the minimum-viable bump first. Expect follow-up commits for:

- Any compile/test fallout in `grails-micronaut`, `grails-test-examples/micronaut*`, and `grails-test-examples/plugins/micronaut-singleton`.
- Possible Serde alignment: `micronautSerdeJacksonVersion=2.11.0` in `gradle.properties` is still on the Micronaut Serde 2.x line while Micronaut 5 GA ships Serde 3.0.0. It is intentionally floated outside the BOM today; whether to bump it is a separate decision pending what the graphql test examples actually need.
- `micronautRxjava2Version=2.9.0` - same situation; out-of-band pin, likely fine but worth confirming.
- `grails-forge` stays on `micronautVersion=4.10.10` (the Forge IS a Micronaut 4.x app, per the comment at `grails-forge/gradle.properties:27`). Out of scope for this PR.

Verification so far:

```
./gradlew validateDependencyVersions          # root: BUILD SUCCESSFUL
./gradlew :grails-gradle:validateDependencyVersions  # grails-gradle: BUILD SUCCESSFUL
```

Full build / test execution is the next step and likely the source of most of the remaining work on this branch.
